### PR TITLE
A few fixes + sample boilerplate 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This collection works with Ansible 2.9+
 2. [RedHat Ansible] 2.9+
 
     ```
-    pip install "ansible>=2.9.2"
+    pip install "ansible>=2.9.10"
     ```
 
 # Installation

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,6 +13,4 @@ issues: "https://github.com/IBM-Cloud/ansible.ibm.cloud/issues"
 tags:
     - ibmcloud
     - cloud
-    - collection
-    - ansible
 repository: "https://github.com/IBM-Cloud/ansible.ibm.cloud"

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,0 +1,8 @@
+version: 1
+
+build_arg_defaults:
+  EE_BASE_IMAGE: "registry.redhat.io/ansible-automation-platform-21/ee-minimal-rhel8:latest"
+ansible_config: "ansible.cfg"
+
+dependencies:
+  python: requirements.txt

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.9.10"

--- a/plugins/modules/ibm_cm_catalog.py
+++ b/plugins/modules/ibm_cm_catalog.py
@@ -14,11 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ANSIBLE_METADATA = {
-    'metadata_version': '1.1',
-    'status': ['preview'],
-    'supported_by': 'community'
-}
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 DOCUMENTATION = r'''
 ---


### PR DESCRIPTION
Will try to leave context for each change made below.

> readme change

changed to as 2.9.10 is when all of the final bits of the collection spec and work was added, while you may not find it much it in the wild still, you will see most if not all collection pin to this `min` versions

> galaxy.yml

tags are only used across galaxy and automation hub to drive search results. anything with them in this context will most likely be a collection

> meta/

this directory is used by ansible-core to determine a plethora of things around runtime vars/things needed for the collection. the runtime file and its `requires_ansible` key will tell ansible (and subsequently the user) if they are using an unsupported version of ansible with this collection. see readme change for context in version selection. you can elect to only support 2.11 and above if you would like, 2.9.x support is not needed unless you wish to support it. note: requires_ansible points to the `ansible_core` version, not the `ansible` version. 

> ibm_cm_catalog

I would run this collection through the sanity suite as it is missing a fair number of boilerplate code as well as also containing a lot of pep8 violations. This boilerplate which you can copy paste throughout, will need to be in any python file that is executed or could be executed via ansible (i.e. anything under plugins/)

Once the sanity suite issues have been resolved, this collection will be ready for release. You can run the sanity suite in any local dev environment via `ansible-test sanity $python_version` or if the machine has docker installed, you can pass the `--docker` command to test all available matrices. Do note that python support goes by ansible version so if you elect to support 2.9.x, you will need to support python 2.7 (included in all vanilla installs of RHEL).  You can support whichever versions of python you like but as of ansible-core 2.12 we do have a hard requirement of python 3.8. That being said, if you are only supporting (lets say 3.8) you can ignore the 2.6-3.7 compile and import tests. Just make sure to note which versions are supported in the readme for customers and users. 

We also have a template for github actions to run the sanity suite if you would like that as well. 